### PR TITLE
rework handling of options

### DIFF
--- a/domain_info.sh
+++ b/domain_info.sh
@@ -102,9 +102,9 @@ display_dns_info() {
 print_help() {
   echo ""
   echo -e "${CYAN}Usage:${RESET} $(basename "$0") ${YELLOW}[-d domain] [-s dns_server] [-h]${RESET}"
-  echo -e "  ${YELLOW}-d domain${RESET}       Domain name to be queried"
-  echo -e "  ${YELLOW}-s dns_server${RESET}   Optional custom DNS server to query"
-  echo -e "  ${YELLOW}-h${RESET}              Display help information"
+  echo -e "${CYAN}Usage:${RESET} $(basename "$0") ${YELLOW}[domain] [@dns_server] [-h]${RESET}"
+  echo -e "  ${YELLOW}domain${RESET}       Domain name to be queried"
+  echo -e "  ${YELLOW}dns_server${RESET}   Optional custom DNS server to query"
   echo ""
   echo -e "Example Usage:"
   echo -e "  $(basename "$0") ${YELLOW}-d example.com${RESET}"
@@ -116,7 +116,7 @@ print_help() {
 bail() {
     echo "${RED}$@${RESET}" >&2
     print_help
-    exit 1
+    exit 3
 }
 
 # Function to check domain status
@@ -145,20 +145,24 @@ check_status_registration() {
 
 error_flag=0  # Initialize error_flag variable
 
-# TODO: make this handle --domain domain
-while getopts ":d:s:h" o; do
-    case "${o}" in
+# TODO: 
+# * handle "--domain domain" long options
+# * resolve bug where "$0 domain -s dns_server" is interpreted as looking up
+# "dns_server" as a domain, against the default dns server. 
+while getopts ":d:s:h" opt ; do
+    case "${opt}" in
         d)
-            [[ -z "$OPTARG" ]] && bail "Option -${o} requires an argument"
             domain=${OPTARG}
             ;;
         s)
-            [[ -z "$OPTARG" ]] && bail "Option -${o} requires an argument"
             dns_server=${OPTARG}
             ;;
         h)
             print_help
             exit 0
+            ;;
+        *)
+            bail "Invalid option or missing argument"
             ;;
     esac
 done

--- a/domain_info.sh
+++ b/domain_info.sh
@@ -35,10 +35,10 @@ display_records() {
   local record_type=$1
   local record_data=$2
   if [ -n "$record_data" ]; then
-    echo -e "\n${CYAN}$record_type record:${RESET}"
+    echo -e "${CYAN}$record_type record:${RESET}"
     echo "$record_data" | sed 's/^/  /'
   else
-    echo -e "\n${RED}$record_type record: - ${RESET}"
+    echo -e "${RED}$record_type record: - ${RESET}"
   fi
 }
 
@@ -46,9 +46,9 @@ display_records() {
 display_a-ptr_records() {
   local record_type=$1
   local ip_addresses=$2
-  [ -z "${ip_addresses}" ] && printf "\n${RED}%4s record: -${RESET}\n" ${record_type} && return
+  [ -z "${ip_addresses}" ] && printf "${RED}%4s record: -${RESET}\n" ${record_type} && return
   
-  printf "\n${CYAN}%s record:${RESET}\n" ${record_type}
+  printf "${CYAN}%s record:${RESET}\n" ${record_type}
   
   for ip in $ip_addresses ; do
      local ptr_info=$(dig +short -x $ip)
@@ -64,7 +64,7 @@ display_a-ptr_records() {
 display_ssl_info() {
   local openssl_info=$(openssl s_client -showcerts -connect $domain:443 -servername $domain </dev/null 2>/dev/null | openssl x509 -noout -subject -dates -ext subjectAltName -issuer 2>/dev/null | grep -v X509v3)
   if [ $? -eq 0 ]; then
-    echo -e "\n${CYAN}[SSL Information]${RESET}"
+    echo -e "${CYAN}[SSL Information]${RESET}"
     echo "$openssl_info" | sed 's/^/  /'
   else
     echo -e "${RED}No SSL information available or cannot be read for $domain on port 443.${RESET}"
@@ -124,10 +124,10 @@ check_domain_status() {
   local domain_status=$(whois $domain | grep "serverHold\|clientHold")
 
   if [[ $domain_status == *"clientHold"* ]]; then
-    echo -e "\n${RED}[Domain Status]${RESET}"
+    echo -e "${RED}[Domain Status]${RESET}"
     echo -e "${YELLOW}Status:${RESET} ${RED}clientHold${RESET}\n\n[Suspended by the registrar or domain provider]\n"
   elif [[ $domain_status == *"serverHold"* ]]; then
-    echo -e "\n${RED}[Domain Status]${RESET}"
+    echo -e "${RED}[Domain Status]${RESET}"
     echo -e "${YELLOW}Status:${RESET} ${RED}serverHold${RESET}\n\n[Suspended by the registry]\n"
   fi
 }

--- a/domain_info.sh
+++ b/domain_info.sh
@@ -148,7 +148,7 @@ error_flag=0  # Initialize error_flag variable
 # TODO: 
 # * handle "--domain domain" long options
 # * resolve bug where "$0 domain -s dns_server" is interpreted as looking up
-# "dns_server" as a domain, against the default dns server. 
+#   "dns_server" as a domain, against the default dns server. 
 while getopts ":d:s:h" opt ; do
     case "${opt}" in
         d)


### PR DESCRIPTION
original options of `-d domain -s server` still works

--domain, --server and --help long options have been removed

Domain and server can now be given as `domain @server` or `@server domain` - aligning with `dig` usage

however, there is a bug where `domain -s server` will do the wrong thing with this code